### PR TITLE
fix: don't use static vars for mfcc computation

### DIFF
--- a/bin/mfcc/_mfcc.c
+++ b/bin/mfcc/_mfcc.c
@@ -205,7 +205,7 @@ void mfcc(double *in, double *mc, const double sampleFreq, const double alpha,
           const int n, const int ceplift, const Boolean dftmode,
           const Boolean usehamming)
 {
-   static double *x = NULL, *px, *wx, *sp, *fb, *dc;
+   double *x = NULL, *px, *wx, *sp, *fb, *dc;
    double energy = 0.0, c0 = 0.0;
    int k;
 


### PR DESCRIPTION
  - Removing static keyword from variable declarations in the mfcc
    function. This allows multiple mfcc computation to be run in
    parallel (such as multiple go routines in Go).